### PR TITLE
Fixed undefined is not a function when refreshing the token

### DIFF
--- a/src/applozic-chat.ios.ts
+++ b/src/applozic-chat.ios.ts
@@ -52,7 +52,7 @@ export class ApplozicChat extends Common {
 
   public refreshToken(token: any, successCallback: any, errorCallback: any) {
     const alRegisterUserClientService = ALRegisterUserClientService.alloc().init();
-    alRegisterUserClientService.updateApnDeviceTokenWithCompletionwithCompletion(token, (response, error) => {
+    alRegisterUserClientService.updateApnDeviceTokenWithCompletionWithCompletion(token, (response, error) => {
       if (response) {
         successCallback(response.dictionary());
       } else {


### PR DESCRIPTION
Fixed an issue while refreshing the token on iOS. 

The given error was:
***** Fatal JavaScript exception - application has been terminated. *****
Native stack trace:
1   0x101289be0 NativeScript::reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*, bool)
2   0x1012ac930 NativeScript::FFICallback<NativeScript::ObjCMethodCallback>::ffiClosureCallback(ffi_cif*, void*, void**, void*)
3   0x101b62618 ffi_closure_SYSV_inner
4   0x101b641b4 .Ldo_closure
5   0x18497d13c <redacted>
6   0x18497c6dc <redacted>
7   0x18497c440 <redacted>
8   0x1849f9e24 <redacted>
9   0x1848b2d60 _CFXNotificationPost
10  0x1852df348 <redacted>
11  0x100c12e74 -[Push success:WithMessage:]
12  0x100c11ab4 -[Push didRegisterForRemoteNotificationsWithDeviceToken:]
13  0x100c13818 -[PushManager my_application:didRegisterForRemoteNotificationsWithDeviceToken:]
14  0x18436aa54 <redacted>
15  0x18436aa14 <redacted>
16  0x184377698 <redacted>
17  0x184993344 <redacted>
18  0x184990f20 <redacted>
19  0x1848b0c58 CFRunLoopRunSpecific
20  0x18675cf84 GSEventRunModal
21  0x18e0095c4 UIApplicationMain
22  0x101b64044 ffi_call_SYSV
23  0x101b62160 ffi_call_int
24  0x101b61c70 ffi_call
25  0x1012691ac NativeScript::FFICall::call(JSC::ExecState*)
26  0x10182b1e0 JSC::LLInt::setUpCall(JSC::ExecState*, JSC::Instruction*, JSC::CodeSpecializationKind, JSC::JSValue, JSC::LLIntCallLinkInfo*)
27  0x101833d24 llint_entry
28  0x101833d34 llint_entry
29  0x101833d34 llint_entry
30  0x10182d1e0 vmEntryToJavaScript
31  0x1017c82f0 JSC::JITCode::execute(JSC::VM*, JSC::ProtoCallFrame*)
JavaScript stack trace:
1   refreshToken@file:///app/tns_modules/nativescript-serviceheroes-applozic/node_modules/nativescript-applozic-chat/applozic-chat.js:41:85
2   @file:///app/tns_modules/nativescript-serviceheroes-applozic/applozic-sh.js:62:30
3   @file:///app/tns_modules/nativescript-serviceheroes-applozic/node_modules/nativescript-push-notifications/push-plugin.js:65:20
4   onReceive@file:///app/tns_modules/tns-core-modules/application/application.js:30:32
5   UIApplicationMain@[native code]
6   start@file:///app/tns_modules/tns-core-modules/application/application.js:272:26
7   run@file:///app/tns_modules/tns-core-modules/application/application.js:300:10
8   anonymous@file:///app/app.js:7:16
9   evaluate@[native code]
10  moduleEvaluation@[native code]
11  @[native code]
12  promiseReactionJob@[native code]
JavaScript error:
file:///app/tns_modules/nativescript-serviceheroes-applozic/node_modules/nativescript-applozic-chat/applozic-chat.js:41:85: JS ERROR TypeError: undefined is not a function (near '...alRegisterUserClientService.updateApnDeviceTokenWithCompletionwithCompletion...')